### PR TITLE
13-build-does-not-update-version-string-in-manpage #close

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ TARGET := $(NAME)
 
 MANPAGE := man1/$(TARGET).1
 
+MANSRC := man1/$(TARGET).1.md
+
 VERSION := lib/version.h
 
 TAG := $(shell git describe --tags)
@@ -19,6 +21,8 @@ COMMIT := $(shell git log -1 HEAD | egrep '^commit' | cut -d' ' -f2)
 AUTHOR := $(shell git log -1 HEAD | egrep '^Author:')
 
 DATE := $(shell git log -1 HEAD | egrep '^Date:')
+
+DATEFMT := $(shell git log -1 HEAD | egrep '^Date:' | cut -d' ' -f5 -f6 -f8)
 
 CC := cc
 
@@ -43,6 +47,7 @@ WFLAGS := -Wall -Wextra
 debug:
 	$(CC) $(CFLAGS) $(LDFLAGS) $(DFLAGS) $(WFLAGS) -o $(TARGET) $(SOURCE)
 
+version: $(VERSION)
 $(VERSION):
 	rm -f $(VERSION)
 	echo "/**\n * DStat lib/version.c\n *\n * Auto-generated at build time.\n */" > $(VERSION)
@@ -52,8 +57,13 @@ $(VERSION):
 	echo "const char *AUTHOR = \"$(AUTHOR)\";" >> $(VERSION)
 	echo "const char *DATE = \"$(DATE)\";"     >> $(VERSION)
 
+manpage: $(MANPAGE)
 $(MANPAGE):
-	$(PD) man1/$(TARGET).1.md -s -t man -o man1/$(TARGET).1 
+	$(shell sed -i.bak -e "s/^footer: .*/footer: $(TAG)/g" $(MANSRC))
+	$(shell sed -i.bak -e "s/^date: .*/date: $(DATEFMT)/g" $(MANSRC))
+	$(PD) man1/$(TARGET).1.md -s -t man -o $(MANPAGE)
+	cp $(MANSRC) README.md
+	rm -f $(MANSRC).bak
 
 $(TARGET):
 	$(CC) $(CFLAGS) $(LDFLAGS) $(WFLAGS) $(OFLAGS) $(TARGET) $(SOURCE)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 title: DSTAT
 section: 1
 header: User Manual
-footer: dstat 0.5.0
-date: 15 February 2024
+footer: 0.5.1-1-g38bffee
+date: Feb 16 2024
 ---
 # NAME
 dstat - Quickly gather and print directory statistics.
@@ -99,6 +99,10 @@ other errors, will cause the program to halt.
 **-v**, **---version**
 : Prints the current software revision and exits.
 
+**-V**, **---Version**
+: Prints verbose software release information (including version tag, Git
+commit ID, author, and date information) and exits.
+
 **-h**, **---help**
 : Display a short help message with usage information.
 
@@ -157,11 +161,7 @@ SOFTWARE.
 
 
 # BUGS
-This release, 0.5.0, is largely non-functional. The core functionality of gathering directory statistics works. 
-
 - Formatting options are hit 'n' miss.
-
-- Version flag non-functional.
 
 - Directory recursion also only works one-level deep before returning an 
 error.

--- a/man1/dstat.1.md
+++ b/man1/dstat.1.md
@@ -2,8 +2,8 @@
 title: DSTAT
 section: 1
 header: User Manual
-footer: dstat 0.5.0
-date: 15 February 2024
+footer: 0.5.1-1-g38bffee
+date: Feb 16 2024
 ---
 # NAME
 dstat - Quickly gather and print directory statistics.
@@ -161,11 +161,7 @@ SOFTWARE.
 
 
 # BUGS
-This release, 0.5.0, is largely non-functional. The core functionality of gathering directory statistics works. 
-
 - Formatting options are hit 'n' miss.
-
-- Version flag non-functional.
 
 - Directory recursion also only works one-level deep before returning an 
 error.


### PR DESCRIPTION
 #comment
 * Updated Makefile to also update the version string and date in both the manpage and README files.