### PR TITLE
9-cwd-is-not-assumed-when-no-directory-specified #close

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 title: DSTAT
 section: 1
 header: User Manual
-footer: 0.5.1-1-g38bffee
+footer: 0.5.2
 date: Feb 16 2024
 ---
 # NAME

--- a/lib/dstat.h
+++ b/lib/dstat.h
@@ -101,7 +101,7 @@ bool dir_test(const char *dn);
  * Print statistics on each (tested) directory.
  * Takes integer index value and struct pointer for stats.
  */
-int get_dirstats(char *dir);
+int get_dirstats(int idx);
 
 /**
  * Takes the number of input directories, a pointer to the list of

--- a/man1/dstat.1.md
+++ b/man1/dstat.1.md
@@ -2,7 +2,7 @@
 title: DSTAT
 section: 1
 header: User Manual
-footer: 0.5.1-1-g38bffee
+footer: 0.5.2
 date: Feb 16 2024
 ---
 # NAME


### PR DESCRIPTION
 #comment
 * Very basic fix to Issue 9, "CWD is not assumed..."; this will be (necessarily) fixed up once we tackle proper recursion.
 * Cleaned up some code, particularly over-long and over-voluminous `dprint` statements.
 * Various minor function signature changes that are likely to change again with the next commit!
 * Replaced `return` statements with `exit()` calls in `main()` handling of `-v`, `-V`, and `-h` flag cases.