### PR TITLE
#close 29-count-header

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 title: DSTAT
 section: 1
 header: User Manual
-footer: 0.6.4-pre-release
+footer: 0.6.4-pre-release-1-gec08da4
 date: Mar 12 2024
 ---
 # NAME

--- a/dstat.c
+++ b/dstat.c
@@ -117,6 +117,7 @@ struct dir_ent_s de = {
     .d_fif = 0, .d_chr = 0, .d_dir = 0,
     .d_blk = 0, .d_reg = 0, .d_lnk = 0,
     .d_sok = 0, .d_wht = 0, .d_unk = 0,
+    .num_hdr = 0,
     .fqdp = NULL
 };
 
@@ -402,7 +403,7 @@ void blockOutput(dir_list_s *paths, enum action act)
 void csvOutput(dir_list_s *paths, enum action act)
 {
     int          i = 0;
-    int  values[8] = {de.d_reg, de.d_dir, de.d_lnk, de.d_blk,
+    int   values[] = {de.d_reg, de.d_dir, de.d_lnk, de.d_blk,
                       de.d_chr, de.d_fif, de.d_sok, de.d_wht};
     char        *c = malloc(sizeof(char));
     char *csv_list = malloc(sizeof(STAT_HDR) + 1024);
@@ -415,14 +416,14 @@ void csvOutput(dir_list_s *paths, enum action act)
             asprintf(&csv_list, "%s%s\n", csv_list, opt.list[i]);
         }
 
-        for ( i = 0 ; i < 8 ; ++i ) {
+        for ( i = 0 ; i < de.num_hdr ; ++i ) {
             asprintf(&csv_list, "%s%s,", csv_list, STAT_HDR[i]);
         }
         asprintf(&csv_list, "%s\b \n", csv_list); /// Remove trailing comma.
     }
 
     /// Push the corresponding values to the memory block.
-    for ( i = 0 ; i < 8 ; ++i ) {
+    for ( i = 0 ; i < de.num_hdr ; ++i ) {
         asprintf(&csv_list, "%s%d,", csv_list, values[i]);
     }
     asprintf(&csv_list, "%s\b \n", csv_list); /// Remove trailing comma.
@@ -447,9 +448,9 @@ void printDeco()
 {
     int i = 0, j = 0;
 
-    for ( i = 0 ; i < 8 ; ++i ) {
+    for ( i = 0 ; i < de.num_hdr ; ++i ) {
         printf("+");
-        for ( j = 0 ; j < 8 ; ++j ) {
+        for ( j = 0 ; j < de.num_hdr ; ++j ) {
             printf("-");
         }
     }
@@ -460,11 +461,12 @@ void printDeco()
  */
 void lineOutput(dir_list_s *paths, enum action act)
 {
-    int i         = 0;
-    int values[8] = {de.d_reg, de.d_dir, de.d_lnk, de.d_blk,
-                     de.d_chr, de.d_fif, de.d_sok, de.d_wht};
+    int i        = 0;
+    int values[] = {de.d_reg, de.d_dir, de.d_lnk, de.d_blk,
+                    de.d_chr, de.d_fif, de.d_sok, de.d_wht};
 
     if ( act == non ) {
+        // stub for continuous output mode, `cnt`
         Dprint("%s", "act is non");
     }
 
@@ -475,7 +477,7 @@ void lineOutput(dir_list_s *paths, enum action act)
         printDeco();
         printf("|");
 
-        for ( i = 0 ; i < 8 ; ++i ) {
+        for ( i = 0 ; i < de.num_hdr ; ++i ) {
             printf("%7s |", STAT_HDR[i]);
         }
 
@@ -485,7 +487,7 @@ void lineOutput(dir_list_s *paths, enum action act)
 
     /// Print the values with decoration.
     printf("|");
-    for ( i = 0 ; i < 8 ; ++i ) {
+    for ( i = 0 ; i < de.num_hdr ; ++i ) {
         printf("%7d |", values[i]);
     }
     printf("\n");
@@ -527,6 +529,9 @@ int displayOutput(dir_list_s *paths)
  */
 int main(int argc, char *argv[])
 {
+    /// Initialise any starting variables not set at compile-time.
+    de.num_hdr = sizeof(STAT_HDR) / sizeof(STAT_HDR[0]);
+
     /// Initialise, read, and set the various user options.
     int param_index = 0;
     cag_option_context context;

--- a/lib/dstat.h
+++ b/lib/dstat.h
@@ -85,6 +85,27 @@
 #define MAXPATHLEN __DARWIN_MAXPATHLEN
 
 /**
+ * The nominal list of file types available from dirent.h entries that will
+ * be displayed, in a sensible order. This, along with `dir_ent_s{}`, below,
+ * should be updated to match your target OS/filesystem dirent.h.
+ */
+char *STAT_HDR[] = {"Regulr", "Dir", "Link", "Block",
+                    "Char", "FIFO", "Socket", "WhtOut"};
+
+/**
+ * This structure holds the variables and pointers for adding dirent.h
+ * statistical entries. It can also hold the following optional or
+ * temporary parameters:
+ *   - `char *fqdp` : A fully-qualified directory path string for passing
+ *                    to the `struct dir_node{}`.
+ */
+struct dir_ent_s {
+    int  d_fif, d_chr, d_dir, d_blk, d_reg, d_lnk, d_sok, d_wht, d_unk;
+    int  num_hdr;
+    char *fqdp;
+};
+
+/**
  * Separate structure for passing selected options to functions.
  */
 struct sel_opts_s {
@@ -101,25 +122,6 @@ struct sel_opts_s {
     char *FILEOPTS; /// placeholder for file handling options
     char *list[];   /// placeholder for massaging a directory list
 };
-
-/**
- * This structure holds the variables and pointers for adding dirent.h
- * statistical entries. It can also hold the following optional or
- * temporary parameters:
- *   - `char *fqdp` : A fully-qualified directory path string for passing
- *                    to the `struct dir_node{}`.
- */
-struct dir_ent_s {
-    int d_fif, d_chr, d_dir, d_blk, d_reg, d_lnk, d_sok, d_wht, d_unk;
-    char *fqdp;
-};
-
-/**
- * The nominal list of file types available from dirent.h entries that will
- * be displayed, in a sensible order.
- */
-char *STAT_HDR[8] = {"Regulr", "Dir", "Link", "Block",
-                     "Char", "FIFO", "Socket", "WhtOut"};
 
 /**
  * The following structs and function declarations enable the linked-list

--- a/man1/dstat.1.md
+++ b/man1/dstat.1.md
@@ -2,7 +2,7 @@
 title: DSTAT
 section: 1
 header: User Manual
-footer: 0.6.4-pre-release
+footer: 0.6.4-pre-release-1-gec08da4
 date: Mar 12 2024
 ---
 # NAME


### PR DESCRIPTION
 #comment
 * Added `num_hdr` element to `dir_ent_s{}`.
 * Removed hardcoded size from array declarations.
 * Populating `de.num_hdr` from `main()`.
 * Replaced loop limits with `de.num_hdr`.
 * Updated documentation in dstat.h for noting dirent.h variability.