### PR TITLE
#close 31-linear-and-csv-dt_unknown-column

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 title: DSTAT
 section: 1
 header: User Manual
-footer: 0.6.5-pre-release
+footer: 0.6.5-pre-release-4-g6083ec0
 date: Mar 12 2024
 ---
 # NAME

--- a/dstat.c
+++ b/dstat.c
@@ -403,10 +403,10 @@ void blockOutput(dir_list_s *paths, enum action act)
 void csvOutput(dir_list_s *paths, enum action act)
 {
     int          i = 0;
-    int   values[] = {de.d_reg, de.d_dir, de.d_lnk, de.d_blk,
-                      de.d_chr, de.d_fif, de.d_sok, de.d_wht};
+    int   values[] = {de.d_reg, de.d_dir, de.d_lnk, de.d_blk, de.d_chr,
+                      de.d_fif, de.d_sok, de.d_wht, de.d_unk};
     char        *c = malloc(sizeof(char));
-    char *csv_list = malloc(sizeof(STAT_HDR) + 1024);
+    char *csv_list = malloc(sizeof(STAT_CSV) + 1024);
 
     /// Add directory list and header if not in quiet-mode.
     if ( ! opt.qit ) {
@@ -417,7 +417,7 @@ void csvOutput(dir_list_s *paths, enum action act)
         }
 
         for ( i = 0 ; i < de.num_hdr ; ++i ) {
-            asprintf(&csv_list, "%s%s,", csv_list, STAT_HDR[i]);
+            asprintf(&csv_list, "%s%s,", csv_list, STAT_CSV[i]);
         }
         asprintf(&csv_list, "%s\b \n", csv_list); /// Remove trailing comma.
     }
@@ -462,8 +462,8 @@ void printDeco()
 void lineOutput(dir_list_s *paths, enum action act)
 {
     int i        = 0;
-    int values[] = {de.d_reg, de.d_dir, de.d_lnk, de.d_blk,
-                    de.d_chr, de.d_fif, de.d_sok, de.d_wht};
+    int values[] = {de.d_reg, de.d_dir, de.d_lnk, de.d_blk, de.d_chr,
+                    de.d_fif, de.d_sok, de.d_wht, de.d_unk};
 
     if ( act == non ) {
         // stub for continuous output mode, `cnt`
@@ -478,7 +478,7 @@ void lineOutput(dir_list_s *paths, enum action act)
         printf("|");
 
         for ( i = 0 ; i < de.num_hdr ; ++i ) {
-            printf("%7s |", STAT_HDR[i]);
+            printf("%8s |", STAT_HDR[i]);
         }
 
         printf("\n");
@@ -488,7 +488,7 @@ void lineOutput(dir_list_s *paths, enum action act)
     /// Print the values with decoration.
     printf("|");
     for ( i = 0 ; i < de.num_hdr ; ++i ) {
-        printf("%7d |", values[i]);
+        printf("%8d |", values[i]);
     }
     printf("\n");
 

--- a/lib/dstat.h
+++ b/lib/dstat.h
@@ -89,9 +89,13 @@
  * be displayed, in a sensible order. This, along with `dir_ent_s{}`, below,
  * should be updated to match your target OS/filesystem dirent.h.
  */
-char *STAT_HDR[] = {"Regulr", "Dir", "Link", "Block",
-                    "Char", "FIFO", "Socket", "WhtOut"};
+char *STAT_HDR[] = {"Regular", "Dir", "Link", "Block", "Char",
+                    "FIFO", "Socket", "WhtOut", "Unknown"};
 
+/// Same as above but with names fully written out for CSV output.
+char *STAT_CSV[] = {"Regular", "Directory", "Link", "Block Special",
+                    "Character Special", "FIFO", "Socket", "White Out",
+                    "Unknown"};
 /**
  * This structure holds the variables and pointers for adding dirent.h
  * statistical entries. It can also hold the following optional or

--- a/man1/dstat.1.md
+++ b/man1/dstat.1.md
@@ -2,7 +2,7 @@
 title: DSTAT
 section: 1
 header: User Manual
-footer: 0.6.5-pre-release
+footer: 0.6.5-pre-release-4-g6083ec0
 date: Mar 12 2024
 ---
 # NAME


### PR DESCRIPTION
 #comment
 * Added columns for `DT_UNKNOWN` in linear and CSV outputs.
   + How the Herculean hooligans did I manage to miss that this whole time?!
 * **NOTE**: Output in linear mode is now 91 characters wide.
   + Added new Issue #33 to be able to select output columns (target Version 2).
 * Added a `STAT_CSV[]` to match `STAT_HDR[]` but with full type names, _a la_ block output mode.