### PR TITLE
#close 37-logfile-functionality-incomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 title: DSTAT
 section: 1
 header: User Manual
-footer: 0.7.1-pre-release
+footer: 0.7.1-pre-release-1-geec4b9a
 date: Mar 12 2024
 ---
 # NAME
@@ -52,7 +52,7 @@ Any unknown file types (e.g not listed in `sys/dirent.h`) will be counted as
 Multiple directories may be specified (see EXAMPLES). If no directory is
 specified, the current working directory is assumed.
 
-**-c**, **---continuous**
+**-C**, **---continuous**
 : Continuously update `STDOUT` with statistical counts. This helps you look 
 busy whilst sipping at your coffee. Implies `-L` / `--linear` output format.
 Count updates are printed on a single line, updated inline, unless the `-L` /
@@ -64,7 +64,7 @@ Count updates are printed on a single line, updated inline, unless the `-L` /
 statistical data (see EXAMPLES). When explicitly specified with the `-c` /
 `--continuous` option, count updates are printed on new lines.
 
-**-C**, **---csv***
+**-c**, **---csv***
 : Prints CSV-formatted output. With the `-o`/`--output` options (see below),
 writes CSV output to the named output file. Has no effect without `-o` flag
 if either `-c` or `-L` flags are also specified.
@@ -106,7 +106,7 @@ commit ID, author, and date information) and exits.
 : Display combined stats for both the `/data` and `/bigdata` filesystems,
 printing the output to a single line, inline, as it becomes available.
 
-**dstat -c -L -q -o /tmp/dstat.out -l /tmp/dstat.log /bigdata | tee > /tmp/dsatat.csv**
+**dstat -C -L -q -o /tmp/dstat.out -l /tmp/dstat.log /bigdata | tee > /tmp/dsatat.csv**
 : Obviously, this one is  a little more involved. In short, monitor progress
 whilst saving state and not stopping on errant directory names but dutifully
 logging such to the logfile (in this case, `/tmp/dstat.log`). In particular, 

--- a/lib/dstat.h
+++ b/lib/dstat.h
@@ -36,6 +36,7 @@
  * Note non-standard github.com:likle/cargs.git
  */
 #include <cargs.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -60,6 +61,12 @@
 #define _BSD_SOURCE
 
 /**
+ * For some reason, we can figure out the system-specific, but not the generic,
+ * MAXPATHLEN.
+ */
+#define MAXPATHLEN __DARWIN_MAXPATHLEN
+
+/**
  * Set up debug printing.
  */
 #define Dprint(fmt, ...)                                                \
@@ -74,15 +81,15 @@
 #endif
 
 /**
- * "Standard Boolean" library required here for function declarations.
+ * Logging function to print non-fatal errors to opt.logfile or fail
+ * appropriately.
  */
-#include <stdbool.h>
+void logError(bool fail, char *msg);
 
 /**
- * For some reason, we can figure out the system-specific, but not the generic,
- * MAXPATHLEN.
+ * Function to write to output opt.outfile if specified.
  */
-#define MAXPATHLEN __DARWIN_MAXPATHLEN
+void writeOut(char *msg);
 
 /**
  * The nominal list of file types available from dirent.h entries that will

--- a/man1/dstat.1.md
+++ b/man1/dstat.1.md
@@ -2,7 +2,7 @@
 title: DSTAT
 section: 1
 header: User Manual
-footer: 0.7.1-pre-release
+footer: 0.7.1-pre-release-1-geec4b9a
 date: Mar 12 2024
 ---
 # NAME
@@ -52,7 +52,7 @@ Any unknown file types (e.g not listed in `sys/dirent.h`) will be counted as
 Multiple directories may be specified (see EXAMPLES). If no directory is
 specified, the current working directory is assumed.
 
-**-c**, **---continuous**
+**-C**, **---continuous**
 : Continuously update `STDOUT` with statistical counts. This helps you look 
 busy whilst sipping at your coffee. Implies `-L` / `--linear` output format.
 Count updates are printed on a single line, updated inline, unless the `-L` /
@@ -64,7 +64,7 @@ Count updates are printed on a single line, updated inline, unless the `-L` /
 statistical data (see EXAMPLES). When explicitly specified with the `-c` /
 `--continuous` option, count updates are printed on new lines.
 
-**-C**, **---csv***
+**-c**, **---csv***
 : Prints CSV-formatted output. With the `-o`/`--output` options (see below),
 writes CSV output to the named output file. Has no effect without `-o` flag
 if either `-c` or `-L` flags are also specified.
@@ -106,7 +106,7 @@ commit ID, author, and date information) and exits.
 : Display combined stats for both the `/data` and `/bigdata` filesystems,
 printing the output to a single line, inline, as it becomes available.
 
-**dstat -c -L -q -o /tmp/dstat.out -l /tmp/dstat.log /bigdata | tee > /tmp/dsatat.csv**
+**dstat -C -L -q -o /tmp/dstat.out -l /tmp/dstat.log /bigdata | tee > /tmp/dsatat.csv**
 : Obviously, this one is  a little more involved. In short, monitor progress
 whilst saving state and not stopping on errant directory names but dutifully
 logging such to the logfile (in this case, `/tmp/dstat.log`). In particular, 


### PR DESCRIPTION
 #close Issue #38
 #comment
 * New `logError()` replaces most `perror()`.
 * New `writeOut()` for writing to opt.outfile without all that tedious mucking about in hyperspace.
 * Per Issue #38 updated options and documentation thereof for consistency.
 * Removed `dir_cnt` from consistency checks since this is primarily just to trigger the scanning of "this" directory.