### PR TITLE
#close 42-directory-uniqueness-redux

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 title: DSTAT
 section: 1
 header: User Manual
-footer: 0.8.0-pre-release-3-ge52e0f0
+footer: 0.8.0-pre-release-4-g4f6a80f
 date: Mar 14 2024
 ---
 # NAME

--- a/dstat.c
+++ b/dstat.c
@@ -212,7 +212,7 @@ dir_node_s *createDirNode(dp_name *dir)
 void checkUniqueDirs(dir_list_s *dir_list)
 {
     dir_node_s *cursor = dir_list->head;
-    char        *dir[] = {NULL};
+    char    *dir[1024] = {NULL}; // hakhakhak /facepalm
     char          *msg = malloc(MAXPATHLEN + 24);
     int       i = 0, j = 0;
 
@@ -223,13 +223,16 @@ void checkUniqueDirs(dir_list_s *dir_list)
     }
 
     for ( i = 0 ; i < dir_list->num_dirs ; ++i ) {
-        for ( j = 0 ; j < dir_list->num_dirs ; ++j ) {
-            if ( (strcmp(dir[i], dir[j]) == 0 ) && ( i != j ) ) {
+        for ( j = i + 1 ; j < dir_list->num_dirs ; ++j ) {
+            if ( strncmp(dir[i], dir[j], MAXPATHLEN) == 0 ) {
                 asprintf(&msg, "%s: directory not unique", dir[i]);
+                Dprint("%s==%s: %s", dir[i], dir[j], msg);
                 logError(true, msg);
             }
         }
     }
+
+    free(msg);
 }
 
 /**
@@ -567,7 +570,7 @@ void lineOutput(dir_list_s *paths, enum action act)
     }
 
     /// Clean up output decorations.
-    if ( ! opt.lin ) printf("\n");
+    if ( ( opt.upd && ! opt.lin ) || ( opt.lin && ! opt.upd ) ) printf("\n");
     if ( ! opt.qit ) printDeco();
 }
 

--- a/man1/dstat.1.md
+++ b/man1/dstat.1.md
@@ -2,7 +2,7 @@
 title: DSTAT
 section: 1
 header: User Manual
-footer: 0.8.0-pre-release-3-ge52e0f0
+footer: 0.8.0-pre-release-4-g4f6a80f
 date: Mar 14 2024
 ---
 # NAME


### PR DESCRIPTION
 #comment
 * Fixed problem where directory uniqueness checking was screwball.
   + The main problem was that the `*dir[]` need to be declared as `*dir[x]`. Argh. But, at least it is just for this function and not a global!
 * Also made several minor enhancements:
   + `j = 0` -> `j = i + 1`: Reduced rounds from _x^2_ to _sum(1 .. x-1)_ .
   + Remembered to `free(msg)`. :P
   + Corrected decoration output for `-C`/`-L` modes.