### PR TITLE
#close 48-weirdness-with-flag-order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ $(MANPAGE):
 $(TARGET):
 	$(CC) $(CFLAGS) $(LDFLAGS) $(WFLAGS) $(OFLAGS) $(TARGET) $(SOURCE)
 
-all: $(VERSION) $(TARGET) $(MANPAGE)
+all: $(VERSION) $(MANPAGE) $(TARGET)
 
 install:
 	install $(TARGET) /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 title: DSTAT
 section: 1
 header: User Manual
-footer: 0.8.3-pre-release
+footer: 0.8.3-pre-release-1-ga8234e6
 date: Mar 18 2024
 ---
 # NAME

--- a/dstat.c
+++ b/dstat.c
@@ -580,13 +580,13 @@ int displayOutput(dir_list_s *paths)
 {
     /// Print output as appropriate to `STDOUT`.
     if ( ( opt.upd || ( opt.lin && ! opt.csv ) )
-         || ( opt.lin && opt.csv && opt.out ) ) {
+         || ( opt.lin && opt.csv ) ) {
         if ( opt.upd ) {
             lineOutput(paths, cnt);
         } else {
             lineOutput(paths, prt);
         }
-    } else if ( opt.csv && ! opt.lin && ! opt.out ) {
+    } else if ( ( opt.csv ) && ( ! opt.lin ) && ( ! opt.out ) ) {
         csvOutput(paths, prt);
     } else {
         blockOutput(paths, prt);

--- a/man1/dstat.1.md
+++ b/man1/dstat.1.md
@@ -2,7 +2,7 @@
 title: DSTAT
 section: 1
 header: User Manual
-footer: 0.8.3-pre-release
+footer: 0.8.3-pre-release-1-ga8234e6
 date: Mar 18 2024
 ---
 # NAME


### PR DESCRIPTION
 * dstat.c: Corrected `-c` CSV-mode to not be dependent on `-o` output-file-mode for deciding printed format.
   + e.g, as the documentation says, "Has no effect without `-o` flag if either `-C` or `-L` flags are also specified."
 * dstat.c: Made the logic for CSV mode output more explicitly clear.
 * Makefile: Changed build order of `all` target to build `$(TARGET)` last.